### PR TITLE
now cards are centered even when 2

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -7,7 +7,7 @@
 </div>
 
 <div class="container mt-5 mb-3">
-  <div class="row g-3">
+  <div class="row g-3 justify-content-center">
     <% @projects.each do |project| %>
       <div class="col-12 col-md-6 col-xl-4">
         <%= link_to shipments_path do %>


### PR DESCRIPTION
Just added a bootstrap class in order to have remaining two cards (or remaining cards < 3 in general) centered, when three layout is standard